### PR TITLE
RestTemplate 및 Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/pda5th/backend/theOne/config/RestTemplateConfig.java
+++ b/src/main/java/pda5th/backend/theOne/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package pda5th.backend.theOne.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/pda5th/backend/theOne/config/SwaggerConfig.java
+++ b/src/main/java/pda5th/backend/theOne/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package pda5th.backend.theOne.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        final String securitySchemeName = "bearerAuth";
+        return new OpenAPI()
+                .info(new Info().title("theOne")
+                        .description("pda5th-theOne api docs")
+                        .version("v0.0.1")
+                        .license(new License().name("Apache 2.0").url("http://localhost:8080")))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}


### PR DESCRIPTION
## 개요

- 외부 API 호출을 위한 RestTemplate 설정을 추가
  - `RestTemplateConfig` 클래스에서 `RestTemplate`을 빈으로 등록하여 프로젝트 내에서 외부 API 호출이 가능하도록 구성
- API 문서화를 위한 Swagger 설정 추가
  - `SwaggerConfig` 클래스를 통해 Swagger UI를 구성하여 API 명세서를 제공

## 작업사항

#2

## 변경로직

- [x] RestTemplate 설정 : `RestTemplateConfig` 클래스 작성
- [x] Swagger 설정: `SwaggerConfig` 클래스 작성


