### PR TITLE
GitHub Actions에서 환경 변수 직접 전달 방식으로 배포 자동화 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,14 +62,23 @@ jobs:
               sudo chown -R 1000:1000 ${{ secrets.MYSQL_DATA_PATH }}
             fi
 
-            # 3. docker-compose.yml 파일 전송 및 설정 적용
+            # 3. docker-compose.yml 파일 전송
             if [ ! -f /home/ec2-user/myproject/docker-compose.yml ]; then
               echo "Uploading docker-compose.yml to EC2"
               scp -i ~/.ssh/id_rsa $GITHUB_WORKSPACE/docker-compose.yml ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/myproject/docker-compose.yml
             fi
 
             # 4. 최신 이미지를 pull하고 Docker Compose 재실행
-            cd /home/ec2-user/myproject
-            docker-compose pull
-            docker-compose down
-            docker-compose up -d
+            ssh -i ~/.ssh/id_rsa ec2-user@${{ secrets.EC2_HOST }} << EOF
+              export MYSQL_IMAGE=${{ secrets.MYSQL_IMAGE }}
+              export MYSQL_CONTAINER_NAME=${{ secrets.MYSQL_CONTAINER_NAME }}
+              export MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}
+              export MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}
+              export MYSQL_USER=${{ secrets.MYSQL_USER }}
+              export MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}
+              export MYSQL_DATA_PATH=${{ secrets.MYSQL_DATA_PATH }}
+            
+              cd /home/ec2-user/myproject
+              docker-compose pull
+              docker-compose down
+              docker-compose up -d


### PR DESCRIPTION
## 개요

- GitHub Actions를 통한 EC2 배포 자동화에서 환경 변수 설정 방식을 개선했습니다.
- `.env` 파일을 생성하지 않고 GitHub Actions `secrets`에 저장된 환경 변수를 `export`하여 Docker Compose에 전달하도록 변경했습니다.

## 작업사항

#1 

## 변경로직

- `docker-compose up` 실행 전 `ssh` 세션 내에서 필요한 환경 변수를 `export`하여 전달하도록 변경
- `docker-compose.yml`에서 환경 변수 참조 방식 수정 없이, 워크플로우 단계에서 바로 주입 가능하도록 처리
- 불필요한 `.env` 파일 생성 과정을 생략하여 설정 절차 단순화