### PR TITLE
EC2 배포 시 SSH 키 및 호스트 키 검증 오류 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,11 +65,11 @@ jobs:
             # 3. docker-compose.yml 파일 전송
             if [ ! -f /home/${{ secrets.EC2_USER }}/docker-compose.yml ]; then
               echo "Uploading docker-compose.yml to EC2"
-              scp -i ~/.ssh/id_rsa $GITHUB_WORKSPACE/docker-compose.yml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/docker-compose.yml
+              scp -o StrictHostKeyChecking=no $GITHUB_WORKSPACE/docker-compose.yml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/docker-compose.yml
             fi
 
             # 4. 최신 이미지를 pull하고 Docker Compose 재실행
-            ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << EOF
+            ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << EOF
               export MYSQL_IMAGE=${{ secrets.MYSQL_IMAGE }}
               export MYSQL_CONTAINER_NAME=${{ secrets.MYSQL_CONTAINER_NAME }}
               export MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}


### PR DESCRIPTION
## 개요
- GitHub Actions 워크플로우에서 EC2 배포 시 발생한 SSH 키 및 호스트 키 검증 문제를 해결했습니다.
- `StrictHostKeyChecking=no` 옵션을 추가하고, SSH 키 설정을 간소화하여 배포 과정에서의 연결 오류를 방지했습니다.

## 작업사항
#1 

## 변경로직
- `scp` 및 `ssh` 명령어에 `StrictHostKeyChecking=no` 옵션을 추가하여 호스트 키 검증 오류 방지
- `appleboy/ssh-action`에서 `key` 파라미터를 사용하여 SSH 키를 직접 전달