### PR TITLE
EC2 배포 워크플로우에서 SSH 세션 중복 제거 및 경로 설정 최적화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # 1. Docker 및 Docker Compose 설치 확인
+            # Docker 및 Docker Compose 설치 확인
             if ! command -v docker &> /dev/null; then
               echo "Docker not found, installing..."
               sudo apt update
@@ -55,31 +55,29 @@ jobs:
               sudo chmod +x /usr/local/bin/docker-compose
             fi
 
-            # 2. MySQL 데이터 디렉토리 설정 (환경 변수 활용)
+            # MySQL 데이터 디렉토리 설정
             if [ ! -d "${{ secrets.MYSQL_DATA_PATH }}" ]; then
               echo "Creating MySQL data volume directory at ${{ secrets.MYSQL_DATA_PATH }}..."
               sudo mkdir -p ${{ secrets.MYSQL_DATA_PATH }}
               sudo chown -R 1000:1000 ${{ secrets.MYSQL_DATA_PATH }}
             fi
 
-            # 3. docker-compose.yml 파일 전송
+            # docker-compose.yml 파일 전송 및 설정 적용
             if [ ! -f /home/${{ secrets.EC2_USER }}/docker-compose.yml ]; then
               echo "Uploading docker-compose.yml to EC2"
               scp -o StrictHostKeyChecking=no $GITHUB_WORKSPACE/docker-compose.yml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/docker-compose.yml
             fi
 
-            # 4. 최신 이미지를 pull하고 Docker Compose 재실행
-            ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << EOF
-              export MYSQL_IMAGE=${{ secrets.MYSQL_IMAGE }}
-              export MYSQL_CONTAINER_NAME=${{ secrets.MYSQL_CONTAINER_NAME }}
-              export MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}
-              export MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}
-              export MYSQL_USER=${{ secrets.MYSQL_USER }}
-              export MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}
-              export MYSQL_DATA_PATH=${{ secrets.MYSQL_DATA_PATH }}
+            # 최신 이미지를 pull하고 Docker Compose 재실행
+            export MYSQL_IMAGE=${{ secrets.MYSQL_IMAGE }}
+            export MYSQL_CONTAINER_NAME=${{ secrets.MYSQL_CONTAINER_NAME }}
+            export MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}
+            export MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}
+            export MYSQL_USER=${{ secrets.MYSQL_USER }}
+            export MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}
+            export MYSQL_DATA_PATH=${{ secrets.MYSQL_DATA_PATH }}
             
-              cd /home/${{ secrets.EC2_USER }}
-              docker-compose pull
-              docker-compose down
-              docker-compose up -d
-            EOF
+            cd /home/${{ secrets.EC2_USER }}
+            docker-compose pull
+            docker-compose down
+            docker-compose up -d


### PR DESCRIPTION
## 개요
- GitHub Actions 워크플로우에서 EC2 배포 시 발생한 SSH 세션 중복 문제를 해결하고, 경로와 환경 변수 설정을 최적화했습니다.
- `appleboy/ssh-action` 내에서 모든 명령어를 실행하도록 설정하여 SSH 인증 오류를 방지하고 배포 프로세스의 안정성을 높였습니다.

## 작업사항
#1  

## 변경로직
- `ssh-action` 내부에서 모든 배포 프로세스를 수행하도록 수정하여 인증 및 권한 문제 해결
- `docker-compose.yml` 파일 전송 경로와 환경 변수 설정을 통해 배포 워크플로우의 신뢰성 강화