### PR TITLE
데이터베이스 엔티티 및 관계 구현 PR

### DIFF
--- a/src/main/java/pda5th/backend/theOne/entity/DailyBoard.java
+++ b/src/main/java/pda5th/backend/theOne/entity/DailyBoard.java
@@ -1,0 +1,33 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Table(name = "daily_boards")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DailyBoard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 게시판 ID
+
+    private LocalDate createdAt; // 생성 날짜
+
+    private String topic; // 수업 주제
+
+    @OneToMany(mappedBy = "dailyBoard", cascade = CascadeType.ALL)
+    private List<Practice> practices;
+
+    @OneToMany(mappedBy = "dailyBoard", cascade = CascadeType.ALL)
+    private List<TIL> tils;
+
+    @OneToMany(mappedBy = "dailyBoard", cascade = CascadeType.ALL)
+    private List<Question> questions;
+}

--- a/src/main/java/pda5th/backend/theOne/entity/HoneyGoals.java
+++ b/src/main/java/pda5th/backend/theOne/entity/HoneyGoals.java
@@ -1,0 +1,23 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "honey_goals")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class HoneyGoals {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 꿈 목표치 ID
+
+    private LocalDate createdAt; // 생성 날짜
+
+    private Integer goal; // 목표치
+}

--- a/src/main/java/pda5th/backend/theOne/entity/HoneyUsers.java
+++ b/src/main/java/pda5th/backend/theOne/entity/HoneyUsers.java
@@ -1,0 +1,28 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "honey_users")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class HoneyUsers {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 매주 목표치 달성량 ID
+
+    private Integer result; // 달성치
+
+    @ManyToOne
+    @JoinColumn(name = "id2")
+    private HoneyGoals honeyGoal; // 목표치 ID 참조
+
+    @ManyToOne
+    @JoinColumn(name = "id3")
+    private User user; // 유저 ID 참조
+}

--- a/src/main/java/pda5th/backend/theOne/entity/Practice.java
+++ b/src/main/java/pda5th/backend/theOne/entity/Practice.java
@@ -1,0 +1,31 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "practices")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Practice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 실습 ID
+
+    private String title; // 실습 제목
+
+    private String assignment; // 실습 문제
+
+    private String answer; // 모델 답안
+
+    private LocalDate createdAt; // 생성 날짜
+
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private DailyBoard dailyBoard; // 게시판 ID 참조
+}

--- a/src/main/java/pda5th/backend/theOne/entity/Question.java
+++ b/src/main/java/pda5th/backend/theOne/entity/Question.java
@@ -1,0 +1,33 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "questions")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 질문 댓글 ID
+
+    private LocalDate createdAt; // 작성 날짜
+
+    private LocalDate updatedAt; // 수정 날짜
+
+    private String content; // 질문 댓글 내용
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user; // 유저 ID 참조
+
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private DailyBoard dailyBoard; // 게시판 ID 참조
+}

--- a/src/main/java/pda5th/backend/theOne/entity/Reply.java
+++ b/src/main/java/pda5th/backend/theOne/entity/Reply.java
@@ -1,0 +1,33 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "replies")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Reply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 답글 ID
+
+    private LocalDate createdAt; // 생성 날짜
+
+    private String updatedAt; // 수정 날짜 (Domain 필드로 표현)
+
+    private String content; // 답글 내용
+
+    @ManyToOne
+    @JoinColumn(name = "question_id")
+    private Question question; // 질문 댓글 ID 참조
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user; // 유저 ID 참조
+}

--- a/src/main/java/pda5th/backend/theOne/entity/TIL.java
+++ b/src/main/java/pda5th/backend/theOne/entity/TIL.java
@@ -1,0 +1,35 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "tils")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TIL {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // TIL ID
+
+    private String title; // TIL 제목
+
+    private String link; // TIL 링크
+
+    private LocalDate createdAt; // 생성 날짜
+
+    private LocalDate updatedAt; // 수정 날짜
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user; // 유저 ID 참조
+
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private DailyBoard dailyBoard; // 게시판 ID 참조
+}

--- a/src/main/java/pda5th/backend/theOne/entity/UsersPractices.java
+++ b/src/main/java/pda5th/backend/theOne/entity/UsersPractices.java
@@ -1,0 +1,29 @@
+package pda5th.backend.theOne.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "users_practices")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UsersPractices {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 실습 완료한 사람 ID
+
+    private LocalDate createdAt; // 생성 날짜
+
+    @ManyToOne
+    @JoinColumn(name = "prac_id")
+    private Practice practice; // 실습 ID 참조
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user; // 유저 ID 참조
+}


### PR DESCRIPTION
## 개요

- 데이터베이스 설계를 기반으로 핵심 엔티티와 관계를 구현

## 작업사항

#13 

## 변경로직

- `DailyBoard`, `Practice`, `TIL`, `Question`, `Reply` 엔티티 추가
- `UsersPractices`, `HoneyUsers`, `HoneyGoals` 엔티티 추가
- 엔티티 간 관계 매핑 설정 (`@ManyToOne`, `@OneToMany` 등)
- Lombok 적용으로 코드 간소화 (`@Getter`, `@Setter`, `@Builder` 등)