### PR TITLE
Feat/#18 mainpage

### DIFF
--- a/src/main/java/pda5th/backend/theOne/controller/DailyBoardController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/DailyBoardController.java
@@ -1,0 +1,40 @@
+package pda5th.backend.theOne.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pda5th.backend.theOne.dto.DailyBoardCreateRequest;
+import pda5th.backend.theOne.dto.DailyBoardDetails;
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.service.DailyBoardService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/boards")
+@RequiredArgsConstructor
+public class DailyBoardController {
+
+    private final DailyBoardService dailyBoardService;
+
+    @PostMapping
+    public ResponseEntity<Void> createBoard(@RequestBody DailyBoardCreateRequest request) {
+        dailyBoardService.createBoard(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public List<DailyBoardDetails> getAllBoards() {
+        return dailyBoardService.getAllBoardDetails();
+    }
+
+    @PutMapping("/{id}")
+    public void updateBoard(@PathVariable Integer id, @RequestBody DailyBoardCreateRequest request) {
+        dailyBoardService.updateBoard(id, request);
+    }
+    @DeleteMapping("/{id}")
+    public void deleteBoard(@PathVariable Integer id) {
+        dailyBoardService.deleteBoard(id);
+    }
+}

--- a/src/main/java/pda5th/backend/theOne/dto/DailyBoardCreateRequest.java
+++ b/src/main/java/pda5th/backend/theOne/dto/DailyBoardCreateRequest.java
@@ -1,0 +1,4 @@
+package pda5th.backend.theOne.dto;
+
+public record DailyBoardCreateRequest(String createdAt, String topic) {
+}

--- a/src/main/java/pda5th/backend/theOne/dto/DailyBoardDetails.java
+++ b/src/main/java/pda5th/backend/theOne/dto/DailyBoardDetails.java
@@ -1,0 +1,15 @@
+package pda5th.backend.theOne.dto;
+
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.entity.Practice;
+import pda5th.backend.theOne.entity.TIL;
+import pda5th.backend.theOne.entity.Question;
+
+import java.util.List;
+
+public record DailyBoardDetails(
+        DailyBoard dailyBoard,
+        List<Practice> top3Practices,
+        List<TIL> top3TILs,
+        List<Question> top3Questions
+) {}

--- a/src/main/java/pda5th/backend/theOne/repository/DailyBoardRepository.java
+++ b/src/main/java/pda5th/backend/theOne/repository/DailyBoardRepository.java
@@ -1,0 +1,15 @@
+package pda5th.backend.theOne.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.entity.Practice;
+
+public interface DailyBoardRepository extends JpaRepository<DailyBoard, Integer> {
+
+    // 특정 DailyBoard에 속한 Practice 목록 페이징 처리
+
+    Page<DailyBoard> findAll(Pageable pageable);
+}

--- a/src/main/java/pda5th/backend/theOne/repository/PracticeRepository.java
+++ b/src/main/java/pda5th/backend/theOne/repository/PracticeRepository.java
@@ -1,0 +1,15 @@
+package pda5th.backend.theOne.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.entity.Practice;
+
+import java.util.List;
+
+public interface PracticeRepository extends JpaRepository<Practice, Integer> {
+
+    // 특정 DailyBoard에 속한 Practice 목록 중 상위 3개 조회
+    @Query("SELECT p FROM Practice p WHERE p.dailyBoard = :dailyBoard ORDER BY p.createdAt DESC limit 3")
+    List<Practice> findTop3ByDailyBoardOrderByCreatedAtDesc(DailyBoard dailyBoard);
+}

--- a/src/main/java/pda5th/backend/theOne/repository/QuestionRepository.java
+++ b/src/main/java/pda5th/backend/theOne/repository/QuestionRepository.java
@@ -1,0 +1,15 @@
+package pda5th.backend.theOne.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.entity.Question;
+
+import java.util.List;
+
+public interface QuestionRepository extends JpaRepository<Question, Integer> {
+
+    // 특정 DailyBoard에 속한 Question 목록 중 상위 3개 조회
+    @Query("SELECT q FROM Question q WHERE q.dailyBoard = :dailyBoard ORDER BY q.createdAt DESC limit 3")
+    List<Question> findTop3ByDailyBoardOrderByCreatedAtDesc(DailyBoard dailyBoard);
+}

--- a/src/main/java/pda5th/backend/theOne/repository/TILRepository.java
+++ b/src/main/java/pda5th/backend/theOne/repository/TILRepository.java
@@ -1,0 +1,16 @@
+
+package pda5th.backend.theOne.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.entity.TIL;
+
+import java.util.List;
+
+public interface TILRepository extends JpaRepository<TIL, Integer> {
+
+    // 특정 DailyBoard에 속한 TIL 목록 중 상위 3개 조회
+    @Query("SELECT t FROM TIL t WHERE t.dailyBoard = :dailyBoard ORDER BY t.createdAt DESC limit 3")
+    List<TIL> findTop3ByDailyBoardOrderByCreatedAtDesc(DailyBoard dailyBoard);
+}

--- a/src/main/java/pda5th/backend/theOne/service/DailyBoardService.java
+++ b/src/main/java/pda5th/backend/theOne/service/DailyBoardService.java
@@ -1,0 +1,77 @@
+package pda5th.backend.theOne.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pda5th.backend.theOne.dto.DailyBoardCreateRequest;
+import pda5th.backend.theOne.dto.DailyBoardDetails;
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.entity.Practice;
+import pda5th.backend.theOne.entity.Question;
+import pda5th.backend.theOne.entity.TIL;
+import pda5th.backend.theOne.repository.DailyBoardRepository;
+import pda5th.backend.theOne.repository.PracticeRepository;
+import pda5th.backend.theOne.repository.QuestionRepository;
+import pda5th.backend.theOne.repository.TILRepository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DailyBoardService {
+
+    private final DailyBoardRepository dailyBoardRepository;
+    private final PracticeRepository practiceRepository;
+    private final TILRepository tilRepository;
+    private final QuestionRepository questionRepository;
+
+
+    // C 생성: 게시판 생성하기
+    public void createBoard(DailyBoardCreateRequest request) {
+        DailyBoard board = DailyBoard.builder()
+                .createdAt(LocalDate.parse(request.createdAt()))
+                .topic(request.topic())
+                .build();
+
+        dailyBoardRepository.save(board);
+    }
+
+    // R 조회: 게시판 모두 가져오기
+    // 모든 DailyBoard와 관련된 상위 3개의 Practice, TIL, Question 가져오기
+    public List<DailyBoardDetails> getAllBoardDetails() {
+        List<DailyBoard> dailyBoards = dailyBoardRepository.findAll();
+        List<DailyBoardDetails> boardDetailsList = new ArrayList<>();
+
+        for (DailyBoard dailyBoard : dailyBoards) {
+            List<Practice> top3Practices = practiceRepository.findTop3ByDailyBoardOrderByCreatedAtDesc(dailyBoard);
+            List<TIL> top3TILs = tilRepository.findTop3ByDailyBoardOrderByCreatedAtDesc(dailyBoard);
+            List<Question> top3Questions = questionRepository.findTop3ByDailyBoardOrderByCreatedAtDesc(dailyBoard);
+
+            DailyBoardDetails detailsDTO = new DailyBoardDetails(dailyBoard, top3Practices, top3TILs, top3Questions);
+            boardDetailsList.add(detailsDTO);
+        }
+        return boardDetailsList;
+    }
+
+
+    // U 수정: 게시판 수정하기
+    @Transactional
+    public void updateBoard(Integer id, DailyBoardCreateRequest request) {
+        // 기존 보드 삭제
+        dailyBoardRepository.deleteById(id);
+        // 새 보드 생성
+        DailyBoard newBoard = DailyBoard.builder()
+                .createdAt(LocalDate.now()) // 현재 날짜로 설정
+                .topic(request.topic())     // request에서 주제 가져오기
+                .build();
+        dailyBoardRepository.save(newBoard);
+    }
+
+
+    // D 삭제: 게시판 삭제
+    public void deleteBoard(Integer id) {
+        dailyBoardRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## 개요

- 메인 페이지의 게시판 CRUD 구현 
## 작업사항

#18

## 변경로직

- Entity 토대로 Repository 생성
- DailyBoardRepository를 페이징 한 후  PracticeRepository, QuestionRepository , TILRepository에서 최신 상위 3개만 받아오도록 쿼리 설정
- DailyBoardService 에서 CRUD 구현 
- > 이때, 조회할 경우 게시판의 질문, til, 실습을 모두 가져와야 함으로 dto 생성해야 함. 
- > 수정과 생성할 경우에도 날짜와 주제만 받아와서 빈 게시판을 생성하고 수정해야 함으로 dto 생성해야 함. 
-  DTO - DailyBoardCreateRequest, DailyBoardDetails 구현 
-  DailyBoardController 구현

