### PR TITLE
Docker 네트워크 및 CORS 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - backend_network
 
   app:
     image: ${APP_IMAGE}
@@ -34,3 +36,9 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+    networks:
+      - backend_network
+
+networks:
+  backend_network:
+    external: true

--- a/src/main/java/pda5th/backend/theOne/config/SecurityConfig.java
+++ b/src/main/java/pda5th/backend/theOne/config/SecurityConfig.java
@@ -11,6 +11,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import pda5th.backend.theOne.common.jwt.filter.JwtRequestFilter;
 import pda5th.backend.theOne.common.security.CustomUserDetailsService;
 
@@ -32,6 +35,19 @@ public class SecurityConfig {
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터를 인증 필터 전에 추가
 
         return http.build(); // SecurityFilterChain 객체 생성
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost"); // 허용할 Origin 설정
+        configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
+        configuration.addAllowedHeader("*"); // 모든 헤더 허용
+        configuration.setAllowCredentials(true); // 인증 정보 포함 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean


### PR DESCRIPTION
## 개요

- 프론트엔드와 백엔드 간의 원활한 통신을 위해 Docker 네트워크와 CORS 설정을 추가

## 작업사항

#20 

## 변경로직

- Docker 네트워크(`backend_network`) 설정 추가
- CORS 설정을 통해 프론트엔드의 API 접근 허용
