### PR TITLE
타이머 기능 구현을 위한 Server-Sent Events (SSE) 도입

### DIFF
--- a/src/main/java/pda5th/backend/theOne/TheOneApplication.java
+++ b/src/main/java/pda5th/backend/theOne/TheOneApplication.java
@@ -2,8 +2,10 @@ package pda5th.backend.theOne;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TheOneApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/pda5th/backend/theOne/config/SecurityConfig.java
+++ b/src/main/java/pda5th/backend/theOne/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (JWT 사용 시 필요 없음)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 비활성화 (Stateless)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/authenticate", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/login", "/api/users/signup").permitAll() // 인증 필요 없는 경로 설정
+                        .requestMatchers("/authenticate", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/login", "/api/users/signup", "/api/timer/*/events").permitAll() // 인증 필요 없는 경로 설정
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터를 인증 필터 전에 추가

--- a/src/main/java/pda5th/backend/theOne/controller/TimerController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/TimerController.java
@@ -1,0 +1,136 @@
+package pda5th.backend.theOne.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import pda5th.backend.theOne.dto.TimerRequest;
+import pda5th.backend.theOne.dto.TimerResponse;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@RestController
+@RequestMapping("/api/timer")
+public class TimerController {
+
+    private final Map<String, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+    private final Map<String, TimerState> timers = new ConcurrentHashMap<>();
+
+    @GetMapping("/{practiceId}/events")
+    @Operation(summary = "타이머 상태 SSE 스트림", description = "practiceId에 대한 타이머 상태를 SSE로 스트리밍합니다.")
+    public SseEmitter streamTimer(@PathVariable String practiceId) {
+        SseEmitter emitter = new SseEmitter(30 * 60 * 1000L); // 30분
+        emitters.computeIfAbsent(practiceId, key -> new CopyOnWriteArrayList<>()).add(emitter);
+
+        emitter.onCompletion(() -> emitters.get(practiceId).remove(emitter));
+        emitter.onTimeout(() -> emitters.get(practiceId).remove(emitter));
+        emitter.onError((ex) -> emitters.get(practiceId).remove(emitter));
+
+        return emitter;
+    }
+
+    @PostMapping("/{practiceId}/start")
+    @Operation(summary = "타이머 시작", description = "주어진 시간(분)으로 타이머를 시작합니다.")
+    public TimerResponse startTimer(@PathVariable String practiceId, @RequestBody TimerRequest request) {
+        TimerState timer = new TimerState(request.minutes() * 60, true);
+        timers.put(practiceId, timer);
+        sendTimerUpdates(practiceId, new TimerResponse(timer.getTimeLeft(), timer.isRunning()));
+        return new TimerResponse(timer.getTimeLeft(), timer.isRunning());
+    }
+
+    @DeleteMapping("/{practiceId}/reset")
+    @Operation(summary = "타이머 리셋", description = "타이머를 초기 상태로 리셋합니다.")
+    public TimerResponse resetTimer(@PathVariable String practiceId) {
+        // 타이머 상태 초기화
+        timers.remove(practiceId);
+        sendTimerUpdates(practiceId, new TimerResponse(0, false));
+
+        // practiceId에 연결된 모든 SseEmitter를 닫고 제거
+        List<SseEmitter> emitterList = emitters.get(practiceId);
+        if (emitterList != null) {
+            emitterList.forEach(SseEmitter::complete);
+            emitters.remove(practiceId);
+        }
+
+        return new TimerResponse(0, false);
+    }
+
+    @PatchMapping("/{practiceId}/pause")
+    @Operation(summary = "타이머 일시정지", description = "타이머를 일시정지합니다.")
+    public TimerResponse pauseTimer(@PathVariable String practiceId) {
+        TimerState timer = timers.get(practiceId);
+        if (timer != null) {
+            timer.setRunning(false);
+            sendTimerUpdates(practiceId, new TimerResponse(timer.getTimeLeft(), false));
+            return new TimerResponse(timer.getTimeLeft(), false);
+        }
+        return new TimerResponse(0, false); // 타이머가 존재하지 않는 경우
+    }
+
+    @PatchMapping("/{practiceId}/resume")
+    @Operation(summary = "타이머 재개", description = "일시정지된 타이머를 재개합니다.")
+    public TimerResponse resumeTimer(@PathVariable String practiceId) {
+        TimerState timer = timers.get(practiceId);
+        if (timer != null) {
+            timer.setRunning(true);
+            sendTimerUpdates(practiceId, new TimerResponse(timer.getTimeLeft(), true));
+            return new TimerResponse(timer.getTimeLeft(), true);
+        }
+        return new TimerResponse(0, false); // 타이머가 존재하지 않는 경우
+    }
+
+    @Scheduled(fixedRate = 1000) // 1초마다 타이머 감소 및 상태 푸시
+    public void decrementTimers() {
+        timers.forEach((practiceId, timer) -> {
+            if (timer.isRunning() && timer.getTimeLeft() > 0) {
+                timer.decrementTime();
+                sendTimerUpdates(practiceId, new TimerResponse(timer.getTimeLeft(), timer.isRunning()));
+            }
+        });
+    }
+
+    private void sendTimerUpdates(String practiceId, TimerResponse response) {
+        List<SseEmitter> emitterList = emitters.getOrDefault(practiceId, new CopyOnWriteArrayList<>());
+        emitterList.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("timer-update")
+                        .data(response));
+            } catch (IOException e) {
+                emitterList.remove(emitter); // 오류 발생 시 Emitter 제거
+            }
+        });
+    }
+
+    static class TimerState {
+        private int timeLeft;
+        private boolean isRunning;
+
+        public TimerState(int timeLeft, boolean isRunning) {
+            this.timeLeft = timeLeft;
+            this.isRunning = isRunning;
+        }
+
+        public int getTimeLeft() {
+            return timeLeft;
+        }
+
+        public void decrementTime() {
+            if (timeLeft > 0) {
+                timeLeft--;
+            }
+        }
+
+        public boolean isRunning() {
+            return isRunning;
+        }
+
+        public void setRunning(boolean running) {
+            isRunning = running;
+        }
+    }
+}

--- a/src/main/java/pda5th/backend/theOne/dto/TimerRequest.java
+++ b/src/main/java/pda5th/backend/theOne/dto/TimerRequest.java
@@ -1,0 +1,3 @@
+package pda5th.backend.theOne.dto;
+
+public record TimerRequest(int minutes) {}

--- a/src/main/java/pda5th/backend/theOne/dto/TimerResponse.java
+++ b/src/main/java/pda5th/backend/theOne/dto/TimerResponse.java
@@ -1,0 +1,3 @@
+package pda5th.backend.theOne.dto;
+
+public record TimerResponse(int timeLeft, boolean isRunning) {}


### PR DESCRIPTION
## 개요

타이머 기능을 구현하기 위해 Server-Sent Events (SSE)를 도입
이를 통해 여러 브라우저에서 동일한 타이머 상태를 실시간으로 공유 가능

## 작업사항

#28 

## 변경로직

- SSE를 위한 환경 설정: Spring Security의 SSE 경로 해제 및 @EnableScheduling 적용
- 타이머 API 구현: 시작, 일시정지, 재개, 리셋 기능을 포함한 API 엔드포인트 추가
- 타이머 상태 변경 시 모든 연결된 클라이언트에 실시간 업데이트 전송
- Swagger 문서에 타이머 API 및 SSE 설명 추가
