### PR TITLE
JWT 인증 및 질문 큐 SSE 구현

### DIFF
--- a/src/main/java/pda5th/backend/theOne/config/SecurityConfig.java
+++ b/src/main/java/pda5th/backend/theOne/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (JWT 사용 시 필요 없음)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 비활성화 (Stateless)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/authenticate", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/login", "/api/users/signup", "/api/timer/*/events").permitAll() // 인증 필요 없는 경로 설정
+                        .requestMatchers("/authenticate", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/login", "/api/users/signup", "/api/timer/*/events", "/api/questions/stream").permitAll() // 인증 필요 없는 경로 설정
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터를 인증 필터 전에 추가

--- a/src/main/java/pda5th/backend/theOne/controller/AuthController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/AuthController.java
@@ -6,13 +6,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import pda5th.backend.theOne.common.jwt.util.JwtUtil;
+import pda5th.backend.theOne.common.security.UserPrincipal;
 import pda5th.backend.theOne.dto.AuthRequest;
 import pda5th.backend.theOne.dto.AuthResponse;
+import pda5th.backend.theOne.dto.UserInfoResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,14 +35,6 @@ public class AuthController {
      */
     @PostMapping("/login")
     @Operation(summary = "로그인 및 JWT 토큰 발급", description = "사용자 이름과 비밀번호를 입력하여 JWT 토큰을 발급받습니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "JWT 토큰 발급 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "500", description = "서버 오류",
-                    content = @Content(mediaType = "application/json"))
-    })
     public AuthResponse login(@RequestBody AuthRequest authRequest) throws Exception {
         try {
             // 사용자 인증 수행
@@ -60,12 +56,11 @@ public class AuthController {
      * @return 간단한 메시지 (JWT가 유효한 경우)
      */
     @GetMapping("/validate-token")
-    @Operation(summary = "JWT 토큰 유효성 확인", description = "발급받은 JWT 토큰이 유효한지 확인합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "JWT 토큰 유효"),
-            @ApiResponse(responseCode = "401", description = "JWT 토큰 유효하지 않음")
-    })
-    public String validateToken() {
-        return "Token is valid"; // 단순한 검증 결과 반환
+    @Operation(summary = "JWT 토큰 유효성 확인", description = "발급받은 JWT 토큰이 유효한지 확인하고, 사용자 정보를 반환합니다.")
+    public ResponseEntity<UserInfoResponse> validateToken(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Integer userId =  userPrincipal.getUser().getId();
+        String username = userPrincipal.getUser().getName();
+        return ResponseEntity.ok(new UserInfoResponse(userId, username));
     }
+
 }

--- a/src/main/java/pda5th/backend/theOne/controller/QuestionQueueController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/QuestionQueueController.java
@@ -1,0 +1,102 @@
+package pda5th.backend.theOne.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.http.ResponseEntity;
+import pda5th.backend.theOne.common.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@RestController
+@RequestMapping("/api/questions")
+public class QuestionQueueController {
+    private final List<Question> questionQueue = new CopyOnWriteArrayList<>();
+    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    @Operation(summary = "질문 큐 SSE 스트림", description = "질문 큐 상태를 SSE로 스트리밍합니다.")
+    @GetMapping("/stream")
+    public SseEmitter streamQuestions() {
+        SseEmitter emitter = new SseEmitter(3600L * 1000L);  // 기본 타임아웃 시간 1시간
+        emitters.add(emitter);
+
+        emitter.onCompletion(() -> emitters.remove(emitter));
+        emitter.onTimeout(() -> emitters.remove(emitter));
+        emitter.onError((e) -> emitters.remove(emitter));
+
+        return emitter;
+    }
+
+    @Operation(summary = "손들기", description = "질문 큐에 사용자 추가(손들기).")
+    @PostMapping
+    public ResponseEntity<String> addQuestion(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        String userId = userPrincipal.getUser().getId().toString();
+        String userName = userPrincipal.getUser().getName();
+
+        if (questionQueue.stream().anyMatch(q -> q.getId().equals(userId))) {
+            return ResponseEntity.badRequest().body("User is already in the queue");
+        }
+
+        questionQueue.add(new Question(userId, userName));
+        sendUpdates();
+
+        return ResponseEntity.ok("Question added by user: " + userName);
+    }
+
+    @Operation(summary = "손내리기", description = "질문 큐에서 사용자 제거(손내리기).")
+    @DeleteMapping
+    public ResponseEntity<String> removeQuestion(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        String userId = userPrincipal.getUser().getId().toString();  // ID 가져오기
+
+        boolean removed = questionQueue.removeIf(q -> q.getId().equals(userId));
+
+        if (!removed) {
+            return ResponseEntity.badRequest().body("User is not in the queue");
+        }
+
+        sendUpdates();
+        return ResponseEntity.ok("Question removed for user: " + userId);
+    }
+
+    @Operation(summary = "질문 큐 확인", description = "현재 질문 큐 상태를 반환합니다.")
+    @GetMapping
+    public ResponseEntity<List<Question>> getQuestions() {
+        return ResponseEntity.ok(questionQueue);
+    }
+
+    // SSE로 질문 큐 업데이트 전송
+    private void sendUpdates() {
+        List<Question> currentQueue = List.copyOf(questionQueue);
+
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(SseEmitter.event().name("questionQueueUpdate").data(currentQueue));
+            } catch (IOException e) {
+                emitters.remove(emitter);
+            }
+        }
+    }
+
+    // 질문 큐: ID와 이름을 저장하는 간단한 DTO로 구성
+    private static class Question {
+        private final String id;
+        private final String name;
+
+        public Question(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+}

--- a/src/main/java/pda5th/backend/theOne/dto/UserInfoResponse.java
+++ b/src/main/java/pda5th/backend/theOne/dto/UserInfoResponse.java
@@ -1,0 +1,3 @@
+package pda5th.backend.theOne.dto;
+
+public record UserInfoResponse(Integer id, String name) { }


### PR DESCRIPTION
## **개요**

- 질문 큐 기능 구현을 위한 **JWT 인증**, **RESTful API**, 및 **SSE(Server-Sent Events)** 기능을 추가
- 클라이언트가 질문 큐를 실시간으로 관리하고, 손들기/손내리기 요청을 처리할 수 있도록 백엔드 로직을 구현

## **작업사항**

#30

## **변경로직**
- **JWT 인증 API**:
  - `/validate-token`을 통해 사용자 토큰 검증 및 유저 정보(id, name) 반환.

- **질문 큐 API**:
  - `GET /api/questions`: 현재 질문 큐 상태 반환.
  - `POST /api/questions`: 사용자를 큐에 추가 (손들기).
  - `DELETE /api/questions`: 사용자를 큐에서 제거 (손내리기).

- **SSE(Server-Sent Events) 구현**:
  - `GET /api/questions/stream`: 실시간으로 질문 큐 상태를 스트리밍.
