### PR TITLE
Feat/#26 practice crud - 특정 보드 내 실습 관련

### DIFF
--- a/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
@@ -21,7 +21,9 @@ import java.util.List;
 public class DetailPracticeController {
     private final DetailPracticeService detailPracticeService;
 
+    // 특정 board에 대한 실습 추가
     @PostMapping("/boards/{id}/practices")
+    @Operation(summary = "실습 추가", description = "실습(+) 버튼을 통한 실습 추가")
     public ResponseEntity<String> createDetailPractice(@PathVariable Integer id, @RequestBody String title) {
         String successTitle = detailPracticeService.createDetailPractice(id, title);
 
@@ -30,6 +32,7 @@ public class DetailPracticeController {
 
     // boradId를 통해 practice 전체 조회해서 {id, title}의 배열 형태로 반환
     @GetMapping("/boards/{id}/practices")
+    @Operation(summary = "특정 Board에 대한 전체 실습 조회", description = "실습들의 {id, title}을 배열 형태로 반환")
     public ResponseEntity<List<PracticeSummaryDto>> getPracticesByBoardId(@PathVariable Integer id) {
         List<PracticeSummaryDto> practices = detailPracticeService.getPracticesByBoardId(id);
 
@@ -38,6 +41,7 @@ public class DetailPracticeController {
 
     // practiceId는 유일하니까 ..
     @PutMapping("/practices/{id}")
+    @Operation(summary = "실습 제목 수정", description = "실습의 title 수정")
     public ResponseEntity<String> updatePracticeTitle(
             @PathVariable Integer id,
             @RequestBody String newTitle) {
@@ -48,6 +52,7 @@ public class DetailPracticeController {
     }
 
     @DeleteMapping("/practices/{id}")
+    @Operation(summary = "실습 삭제", description = "실습 삭제, users_practices에 값이 있어도 cascade 삭제 적용")
     public ResponseEntity<String> deletePractice (
             @PathVariable Integer id) {
 

--- a/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
@@ -7,9 +7,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import pda5th.backend.theOne.common.security.UserPrincipal;
 import pda5th.backend.theOne.dto.PracticeResponseDto;
+import pda5th.backend.theOne.dto.PracticeSummaryDto;
 import pda5th.backend.theOne.entity.User;
 import pda5th.backend.theOne.service.DetailPracticeService;
 import pda5th.backend.theOne.service.PracticeService;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +26,14 @@ public class DetailPracticeController {
         String successTitle = detailPracticeService.createDetailPractice(id, title);
 
         return ResponseEntity.ok("success: " + successTitle);
+    }
+
+    // boradId를 통해 practice 전체 조회해서 {id, title}의 배열 형태로 반환
+    @GetMapping("/boards/{id}/practices")
+    public ResponseEntity<List<PracticeSummaryDto>> getPracticesByBoardId(@PathVariable Integer id) {
+        List<PracticeSummaryDto> practices = detailPracticeService.getPracticesByBoardId(id);
+
+        return ResponseEntity.ok(practices);
     }
 
     // practiceId는 유일하니까 ..

--- a/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
@@ -3,8 +3,11 @@ package pda5th.backend.theOne.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import pda5th.backend.theOne.common.security.UserPrincipal;
 import pda5th.backend.theOne.dto.PracticeResponseDto;
+import pda5th.backend.theOne.entity.User;
 import pda5th.backend.theOne.service.DetailPracticeService;
 import pda5th.backend.theOne.service.PracticeService;
 
@@ -31,6 +34,15 @@ public class DetailPracticeController {
         String updatedTitle = detailPracticeService.updatePracticeTitle(id, newTitle);
 
         return ResponseEntity.ok("Updated title: " + updatedTitle);
+    }
+
+    @DeleteMapping("/practices/{id}")
+    public ResponseEntity<String> deletePractice (
+            @PathVariable Integer id) {
+
+        Integer deletedPracticeId = detailPracticeService.deletePractice(id);
+
+        return ResponseEntity.ok("Deleted practiceId: " + deletedPracticeId);
     }
 
 }

--- a/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
@@ -23,12 +23,12 @@ public class DetailPracticeController {
     }
 
     // practiceId는 유일하니까 ..
-    @PutMapping("/practices/{practiceId}")
+    @PutMapping("/practices/{id}")
     public ResponseEntity<String> updatePracticeTitle(
-            @PathVariable Integer practiceId,
+            @PathVariable Integer id,
             @RequestBody String newTitle) {
 
-        String updatedTitle = detailPracticeService.updatePracticeTitle(practiceId, newTitle);
+        String updatedTitle = detailPracticeService.updatePracticeTitle(id, newTitle);
 
         return ResponseEntity.ok("Updated title: " + updatedTitle);
     }

--- a/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
@@ -21,5 +21,16 @@ public class DetailPracticeController {
 
         return ResponseEntity.ok("success: " + successTitle);
     }
-    
+
+    // practiceId는 유일하니까 ..
+    @PutMapping("/practices/{practiceId}")
+    public ResponseEntity<String> updatePracticeTitle(
+            @PathVariable Integer practiceId,
+            @RequestBody String newTitle) {
+
+        String updatedTitle = detailPracticeService.updatePracticeTitle(practiceId, newTitle);
+
+        return ResponseEntity.ok("Updated title: " + updatedTitle);
+    }
+
 }

--- a/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/DetailPracticeController.java
@@ -1,0 +1,25 @@
+package pda5th.backend.theOne.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pda5th.backend.theOne.dto.PracticeResponseDto;
+import pda5th.backend.theOne.service.DetailPracticeService;
+import pda5th.backend.theOne.service.PracticeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api")
+
+public class DetailPracticeController {
+    private final DetailPracticeService detailPracticeService;
+
+    @PostMapping("/boards/{id}/practices")
+    public ResponseEntity<String> createDetailPractice(@PathVariable Integer id, @RequestBody String title) {
+        String successTitle = detailPracticeService.createDetailPractice(id, title);
+
+        return ResponseEntity.ok("success: " + successTitle);
+    }
+    
+}

--- a/src/main/java/pda5th/backend/theOne/controller/PracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/PracticeController.java
@@ -56,14 +56,14 @@ public class PracticeController {
     }
 
     @DeleteMapping("{id}/users_practices")
-    @Operation(summary = "제출 취소", description = "제출취소 버튼을 누르면 로그인된 userId값과 pracId를 비교하여 삭제 후, 삭제된 userName을 반환합니다.")
+    @Operation(summary = "제출 취소", description = "제출취소 버튼을 누르면 로그인된 userId값과 pracId를 비교하여 삭제 후, 삭제된 userId를 반환합니다.")
     public ResponseEntity<String> deleteSumbitUser(
             @PathVariable Integer id,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
         User user = userPrincipal.getUser();
-        String deletedUserName = practiceService.deleteSumbitUser(id, user);
+        int deletedUserId = practiceService.deleteSumbitUser(id, user);
 
-        return ResponseEntity.ok("deleted user: " + deletedUserName);
+        return ResponseEntity.ok("deleted userId: " + deletedUserId);
     }
 }

--- a/src/main/java/pda5th/backend/theOne/dto/PracticeSummaryDto.java
+++ b/src/main/java/pda5th/backend/theOne/dto/PracticeSummaryDto.java
@@ -1,0 +1,10 @@
+package pda5th.backend.theOne.dto;
+
+// boardId에 대한 practice 전체 조회 할 때, {id, title} 만 반환하기 위한 DTO
+// 특정 boardId에 해당하는 Practice 목록 조회 시 사용할 DTO
+public record PracticeSummaryDto(Integer id, String title) {
+
+    public static PracticeSummaryDto fromEntity(pda5th.backend.theOne.entity.Practice practice) {
+        return new PracticeSummaryDto(practice.getId(), practice.getTitle());
+    }
+}

--- a/src/main/java/pda5th/backend/theOne/entity/Practice.java
+++ b/src/main/java/pda5th/backend/theOne/entity/Practice.java
@@ -3,6 +3,7 @@ package pda5th.backend.theOne.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import java.util.Set;
 
 @Entity
 @Table(name = "practices")
@@ -28,4 +29,7 @@ public class Practice {
     @ManyToOne
     @JoinColumn(name = "board_id")
     private DailyBoard dailyBoard; // 게시판 ID 참조
+
+    @OneToMany(mappedBy = "practice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UsersPractices> usersPractices; // 연관된 UsersPractices -> cascade 삭제를 위함
 }

--- a/src/main/java/pda5th/backend/theOne/repository/DetailPracticeRepository.java
+++ b/src/main/java/pda5th/backend/theOne/repository/DetailPracticeRepository.java
@@ -1,7 +1,16 @@
 package pda5th.backend.theOne.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import pda5th.backend.theOne.dto.PracticeSummaryDto;
 import pda5th.backend.theOne.entity.Practice;
 
+import java.util.List;
+
 public interface DetailPracticeRepository extends JpaRepository<Practice, Integer> {
+    // boardId에 해당하는 Practice 목록 조회
+    @Query("SELECT new pda5th.backend.theOne.dto.PracticeSummaryDto(p.id, p.title) " +
+            "FROM Practice p WHERE p.dailyBoard.id = :boardId")
+    List<PracticeSummaryDto> findPracticeSummariesByBoardId(@Param("boardId") Integer boardId);
 }

--- a/src/main/java/pda5th/backend/theOne/repository/DetailPracticeRepository.java
+++ b/src/main/java/pda5th/backend/theOne/repository/DetailPracticeRepository.java
@@ -1,0 +1,7 @@
+package pda5th.backend.theOne.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import pda5th.backend.theOne.entity.Practice;
+
+public interface DetailPracticeRepository extends JpaRepository<Practice, Integer> {
+}

--- a/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
+++ b/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
@@ -1,0 +1,36 @@
+package pda5th.backend.theOne.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import pda5th.backend.theOne.entity.DailyBoard;
+import pda5th.backend.theOne.entity.Practice;
+import pda5th.backend.theOne.repository.DailyBoardRepository;
+import pda5th.backend.theOne.repository.DetailPracticeRepository;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class DetailPracticeService {
+
+    private final DetailPracticeRepository detailPracticeRepository;
+    private final DailyBoardRepository dailyBoardRepository;
+
+    // 실습(+) 버튼으로 title로 practice 테이블 생성하기
+    public String createDetailPractice(Integer boardId, String title) {
+        DailyBoard dailyBoard = dailyBoardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("Board not found"));
+
+        Practice practice = Practice.builder()
+                .title(title)
+                .assignment(null)
+                .answer(null)
+                .createdAt(LocalDate.now())
+                .dailyBoard(dailyBoard)
+                .build();
+
+        detailPracticeRepository.save(practice);
+
+        return title;
+    }
+}

--- a/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
+++ b/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import pda5th.backend.theOne.entity.DailyBoard;
 import pda5th.backend.theOne.entity.Practice;
+import pda5th.backend.theOne.entity.User;
+import pda5th.backend.theOne.entity.UsersPractices;
 import pda5th.backend.theOne.repository.DailyBoardRepository;
 import pda5th.backend.theOne.repository.DetailPracticeRepository;
 
@@ -45,4 +47,16 @@ public class DetailPracticeService {
 
         return newTitle;
     }
+
+    public Integer deletePractice(Integer id) {
+        Practice practice = detailPracticeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Practice not found"));
+
+        // practiceId 통해 특정 pratice 삭제 (cascade)
+        detailPracticeRepository.delete(practice);
+
+        // 삭제한 PracticeId 반환
+        return id;
+    }
+
 }

--- a/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
+++ b/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
@@ -2,6 +2,8 @@ package pda5th.backend.theOne.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import pda5th.backend.theOne.dto.PracticeResponseDto;
+import pda5th.backend.theOne.dto.PracticeSummaryDto;
 import pda5th.backend.theOne.entity.DailyBoard;
 import pda5th.backend.theOne.entity.Practice;
 import pda5th.backend.theOne.entity.User;
@@ -10,6 +12,8 @@ import pda5th.backend.theOne.repository.DailyBoardRepository;
 import pda5th.backend.theOne.repository.DetailPracticeRepository;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +38,11 @@ public class DetailPracticeService {
         detailPracticeRepository.save(practice);
 
         return title;
+    }
+
+    // boradId에 대한 Practice 전체 조회
+    public List<PracticeSummaryDto> getPracticesByBoardId(Integer boardId) {
+        return detailPracticeRepository.findPracticeSummariesByBoardId(boardId);
     }
 
     // practiceId로 title(실습 제목) 수정하기

--- a/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
+++ b/src/main/java/pda5th/backend/theOne/service/DetailPracticeService.java
@@ -33,4 +33,16 @@ public class DetailPracticeService {
 
         return title;
     }
+
+    // practiceId로 title(실습 제목) 수정하기
+    public String updatePracticeTitle(Integer practiceId, String newTitle) {
+        Practice practice = detailPracticeRepository.findById(practiceId)
+                .orElseThrow(() -> new RuntimeException("Practice not found"));
+
+        // title 업데이트
+        practice.setTitle(newTitle);
+        detailPracticeRepository.save(practice);
+
+        return newTitle;
+    }
 }

--- a/src/main/java/pda5th/backend/theOne/service/PracticeService.java
+++ b/src/main/java/pda5th/backend/theOne/service/PracticeService.java
@@ -76,15 +76,15 @@ public class PracticeService {
         return user.getName();
     }
 
-    public String deleteSumbitUser(Integer id, User user) {
+    public Integer deleteSumbitUser(Integer id, User user) {
         UsersPractices usersPractices = usersPracticesRepository.findByPracticeIdAndUserId(id, user.getId())
                 .orElseThrow(() -> new IllegalArgumentException("usersPractice not found with id: " + id));
 
         // 엔티티 삭제
         usersPracticesRepository.delete(usersPractices);
 
-        // 삭제된 유저의 이름 반환
-        return user.getName();
+        // 삭제된 유저의 id 반환
+        return user.getId();
 
     }
 


### PR DESCRIPTION
## 개요

- 특정 보드 내 실습 관련 CRUD API를 구현

## 작업사항

- #26 

## 변경로직
- 사용자 완료 상태 삭제 API(#17)에 대한
- submitUserDelete 에서 반환 값 userName -> userId로 변경

- 특정 보드 내 실습 관련 CRUD API를 구현
  - 특정 보드에 대한 실습 전체 조회 (id, title)
  - 실습(+) 버튼으로 실습 추가
  - 실습 제목 수정
  - 실습 삭제