### PR TITLE
실습 상세 페이지에서 발생한 두 가지 주요 문제 해결

### DIFF
--- a/src/main/java/pda5th/backend/theOne/controller/PracticeController.java
+++ b/src/main/java/pda5th/backend/theOne/controller/PracticeController.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import pda5th.backend.theOne.common.security.UserPrincipal;
 import pda5th.backend.theOne.dto.PracticeResponseDto;
+import pda5th.backend.theOne.dto.PracticeUpdateRequest;
 import pda5th.backend.theOne.entity.User;
 import pda5th.backend.theOne.service.PracticeService;
 
@@ -27,8 +28,8 @@ public class PracticeController {
     @Operation(summary = "문제 내용 수정", description = "편집 버튼을 누른 후, 문제 내용을 수정하고 완료버튼을 눌러 문제 내용을 수정합니다.")
     public ResponseEntity<String> updateAssignment(
             @PathVariable Integer id,
-            @RequestBody String newAssignment) {
-        String updatedAssignment = practiceService.updateAssignment(id, newAssignment);
+            @RequestBody PracticeUpdateRequest request) {
+        String updatedAssignment = practiceService.updateAssignment(id, request.newContent());
 
         return ResponseEntity.ok("Updated assignment: " + updatedAssignment);
     }
@@ -37,8 +38,8 @@ public class PracticeController {
     @Operation(summary = "모범답안 내용 수정", description = "편집 버튼을 누른 후, 문제 내용을 수정하고 완료버튼을 눌러 모범답안 내용을 수정합니다.")
     public ResponseEntity<String> updateAnswer(
             @PathVariable Integer id,
-            @RequestBody String newAnswer) {
-        String updatedAnswer = practiceService.updateAnswer(id, newAnswer);
+            @RequestBody PracticeUpdateRequest request) {
+        String updatedAnswer = practiceService.updateAnswer(id, request.newContent());
 
         return ResponseEntity.ok("updated answer: " + updatedAnswer);
     }

--- a/src/main/java/pda5th/backend/theOne/dto/PracticeUpdateRequest.java
+++ b/src/main/java/pda5th/backend/theOne/dto/PracticeUpdateRequest.java
@@ -1,0 +1,3 @@
+package pda5th.backend.theOne.dto;
+
+public record PracticeUpdateRequest(String newContent) { }

--- a/src/main/java/pda5th/backend/theOne/entity/UsersPractices.java
+++ b/src/main/java/pda5th/backend/theOne/entity/UsersPractices.java
@@ -5,7 +5,12 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "users_practices")
+@Table(
+        name = "users_practices",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"prac_id", "user_id"})
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
## 개요

- 실습 상세 페이지에서 발생한 두 가지 주요 문제(문제 내용 저장 시 "" 포함 및 제출 중복 저장)를 해결하기 위한 수정 작업

## 작업사항

#37 

## 변경로직

1. **문제 내용 저장 로직 변경**:
   - 기존에는 `String` 타입으로 데이터를 받아 처리하던 방식에서, DTO를 활용해 데이터 구조를 명확히 전달하도록 수정
   
2. **중복 제출 방지 로직 추가**:
   - `users_practices` 테이블에 유니크 제약 조건을 추가하여 동일 사용자와 실습 ID 조합의 중복 저장을 방지