### PR TITLE
DTO 변환으로 순환 참조 문제 해결

### DIFF
--- a/src/main/java/pda5th/backend/theOne/dto/DailyBoardDetails.java
+++ b/src/main/java/pda5th/backend/theOne/dto/DailyBoardDetails.java
@@ -2,14 +2,90 @@ package pda5th.backend.theOne.dto;
 
 import pda5th.backend.theOne.entity.DailyBoard;
 import pda5th.backend.theOne.entity.Practice;
-import pda5th.backend.theOne.entity.TIL;
 import pda5th.backend.theOne.entity.Question;
+import pda5th.backend.theOne.entity.TIL;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record DailyBoardDetails(
-        DailyBoard dailyBoard,
-        List<Practice> top3Practices,
-        List<TIL> top3TILs,
-        List<Question> top3Questions
-) {}
+        DailyBoardDTO dailyBoard,
+        List<PracticeDTO> top3Practices,
+        List<TILDTO> top3TILs,
+        List<QuestionDTO> top3Questions
+) {
+    // DailyBoard와 관련 엔티티를 받아서 DTO로 변환하는 메서드
+    public static DailyBoardDetails fromEntity(
+            DailyBoard dailyBoard,
+            List<Practice> practices,
+            List<TIL> tils,
+            List<Question> questions
+    ) {
+        return new DailyBoardDetails(
+                DailyBoardDTO.fromEntity(dailyBoard),
+                practices.stream().map(PracticeDTO::fromEntity).collect(Collectors.toList()),
+                tils.stream().map(TILDTO::fromEntity).collect(Collectors.toList()),
+                questions.stream().map(QuestionDTO::fromEntity).collect(Collectors.toList())
+        );
+    }
+
+    // DailyBoard DTO 내부 클래스
+    public static record DailyBoardDTO(
+            Integer id,
+            String createdAt,
+            String topic
+    ) {
+        public static DailyBoardDTO fromEntity(DailyBoard dailyBoard) {
+            return new DailyBoardDTO(
+                    dailyBoard.getId(),
+                    dailyBoard.getCreatedAt().toString(),
+                    dailyBoard.getTopic()
+            );
+        }
+    }
+
+    // Practice DTO 내부 클래스
+    public static record PracticeDTO(
+            Integer id,
+            String title,
+            String assignment,
+            String answer
+    ) {
+        public static PracticeDTO fromEntity(Practice practice) {
+            return new PracticeDTO(
+                    practice.getId(),
+                    practice.getTitle(),
+                    practice.getAssignment(),
+                    practice.getAnswer()
+            );
+        }
+    }
+
+    // TIL DTO 내부 클래스
+    public static record TILDTO(
+            Integer id,
+            String title,
+            String link
+    ) {
+        public static TILDTO fromEntity(TIL til) {
+            return new TILDTO(
+                    til.getId(),
+                    til.getTitle(),
+                    til.getLink()
+            );
+        }
+    }
+
+    // Question DTO 내부 클래스
+    public static record QuestionDTO(
+            Integer id,
+            String content
+    ) {
+        public static QuestionDTO fromEntity(Question question) {
+            return new QuestionDTO(
+                    question.getId(),
+                    question.getContent()
+            );
+        }
+    }
+}

--- a/src/main/java/pda5th/backend/theOne/service/DailyBoardService.java
+++ b/src/main/java/pda5th/backend/theOne/service/DailyBoardService.java
@@ -47,20 +47,12 @@ public class DailyBoardService {
         List<DailyBoardDetails> boardDetailsList = new ArrayList<>();
 
         for (DailyBoard dailyBoard : dailyBoardsPage) {
-            // 특정 DailyBoard에 속한 모든 Practice, TIL, Question 가져오기
-//            List<Practice> practices = practiceRepository.findByDailyBoardOrderByCreatedAtDesc(dailyBoard);
-//            List<TIL> tils = tilRepository.findByDailyBoardOrderByCreatedAtDesc(dailyBoard);
-//            List<Question> questions = questionRepository.findByDailyBoardOrderByCreatedAtDesc(dailyBoard);
-//            DailyBoardDetails detailsDTO = new DailyBoardDetails(dailyBoard, practices, tils, questions);
-
-
             List<Practice> top3Practices = practiceRepository.findTop3ByDailyBoardOrderByCreatedAtDesc(dailyBoard.getId());
             List<TIL> top3TILs = tilRepository.findTop3ByDailyBoardOrderByCreatedAtDesc(dailyBoard.getId());
             List<Question> top3Questions = questionRepository.findTop3ByDailyBoardOrderByCreatedAtDesc(dailyBoard.getId());
 
-            DailyBoardDetails detailsDTO = new DailyBoardDetails(dailyBoard, top3Practices, top3TILs, top3Questions);
+            DailyBoardDetails detailsDTO = DailyBoardDetails.fromEntity(dailyBoard, top3Practices, top3TILs, top3Questions);
             boardDetailsList.add(detailsDTO);
-
         }
         return boardDetailsList;
     }


### PR DESCRIPTION
## 개요

- 엔티티 간 순환 참조 문제를 해결하기 위해 DTO 변환을 적용

## 작업사항

#43 

## 변경로직

- API 응답에서 순환 참조를 방지하기 위해 엔티티 대신 DTO를 반환하도록 수정
  - `DailyBoardDetails` DTO 및 내부 변환 로직 구현 
  - 서비스 계층에서 DTO 변환 적용